### PR TITLE
Adds calibration info when inserting new records

### DIFF
--- a/Clients/Apple/FitnessTracker/FitnessTracker/Base.lproj/Main.storyboard
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Base.lproj/Main.storyboard
@@ -124,7 +124,7 @@
                                 </items>
                             </navigationBar>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Bn6-5R-vl7">
-                                <rect key="frame" x="16" y="74" width="343" height="284"/>
+                                <rect key="frame" x="16" y="74" width="343" height="369"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hFF-Hf-jvm" userLabel="Height">
                                         <rect key="frame" x="0.0" y="0.0" width="343" height="50"/>
@@ -171,50 +171,127 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d5N-Au-qPb" userLabel="Weight">
-                                        <rect key="frame" x="0.0" y="62" width="343" height="50"/>
+                                    <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LrA-ea-wSA">
+                                        <rect key="frame" x="0.0" y="62" width="343" height="135"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="bottom" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="kg" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="49R-0v-uMQ">
-                                                <rect key="frame" x="317.5" y="28.5" width="17.5" height="14.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                <color key="textColor" red="1" green="1" blue="1" alpha="0.79670724690000005" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Weight" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8tE-0S-d6L">
-                                                <rect key="frame" x="8" y="12" width="52" height="18"/>
-                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WA5-YQ-jRa">
-                                                <rect key="frame" x="204.5" y="12" width="110" height="30"/>
-                                                <color key="backgroundColor" red="0.99639644859999998" green="1" blue="0.97138376749999999" alpha="0.14999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="35"/>
-                                                <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
-                                                <connections>
-                                                    <outlet property="delegate" destination="IdY-KO-rib" id="WFm-2l-kbK"/>
-                                                </connections>
-                                            </textField>
+                                            <stackView contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="7XZ-t6-0Xx">
+                                                <rect key="frame" x="0.0" y="0.0" width="343" height="135"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d5N-Au-qPb" userLabel="Weight">
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="50"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="bottom" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="kg" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="49R-0v-uMQ">
+                                                                <rect key="frame" x="321" y="28.5" width="14" height="14.5"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                                <color key="textColor" red="1" green="1" blue="1" alpha="0.79670724690000005" colorSpace="calibratedRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Weight" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8tE-0S-d6L">
+                                                                <rect key="frame" x="8" y="12" width="52" height="18"/>
+                                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WA5-YQ-jRa">
+                                                                <rect key="frame" x="208" y="12" width="110" height="30"/>
+                                                                <color key="backgroundColor" red="0.99639644859999998" green="1" blue="0.97138376749999999" alpha="0.14999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="35"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
+                                                                <connections>
+                                                                    <outlet property="delegate" destination="IdY-KO-rib" id="WFm-2l-kbK"/>
+                                                                </connections>
+                                                            </textField>
+                                                        </subviews>
+                                                        <color key="backgroundColor" red="1" green="0.42649608529999999" blue="0.1505924418" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstItem="WA5-YQ-jRa" firstAttribute="top" secondItem="8tE-0S-d6L" secondAttribute="top" id="9KZ-DI-mf3"/>
+                                                            <constraint firstItem="49R-0v-uMQ" firstAttribute="leading" secondItem="WA5-YQ-jRa" secondAttribute="trailing" constant="3" id="IfM-gD-47X"/>
+                                                            <constraint firstAttribute="height" constant="50" id="dtd-51-zuO"/>
+                                                            <constraint firstItem="8tE-0S-d6L" firstAttribute="leading" secondItem="d5N-Au-qPb" secondAttribute="leading" constant="8" id="fiJ-y3-bPh"/>
+                                                            <constraint firstItem="8tE-0S-d6L" firstAttribute="top" secondItem="d5N-Au-qPb" secondAttribute="top" constant="11.5" id="qCR-Nd-ZdH"/>
+                                                            <constraint firstItem="WA5-YQ-jRa" firstAttribute="baseline" secondItem="49R-0v-uMQ" secondAttribute="baseline" id="sOM-uz-ZIv"/>
+                                                            <constraint firstAttribute="trailing" secondItem="49R-0v-uMQ" secondAttribute="trailing" constant="8" id="uNZ-PO-gzd"/>
+                                                        </constraints>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                <integer key="value" value="0"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </view>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="KTe-rI-vJ5">
+                                                        <rect key="frame" x="0.0" y="54" width="343" height="31"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Add calibration fix" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wXC-Am-iM8">
+                                                                <rect key="frame" x="0.0" y="0.0" width="288" height="31"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="RuH-4O-40I">
+                                                                <rect key="frame" x="294" y="0.0" width="51" height="31"/>
+                                                                <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
+                                                            </switch>
+                                                        </subviews>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="31" id="10q-As-uyj"/>
+                                                        </constraints>
+                                                    </stackView>
+                                                    <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Owk-ao-Zos">
+                                                        <rect key="frame" x="0.0" y="89" width="343" height="46"/>
+                                                        <subviews>
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Expected (Kg). Ex: 20" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UoH-C8-ZLc">
+                                                                <rect key="frame" x="0.0" y="0.0" width="171.5" height="46"/>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                                <color key="tintColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                                <nil key="textColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="decimalPad" returnKeyType="next"/>
+                                                            </textField>
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Actual (Kg). Ex: 19.7" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rg2-yE-t4Q">
+                                                                <rect key="frame" x="171.5" y="0.0" width="171.5" height="46"/>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                                <nil key="textColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="decimalPad" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
+                                                            </textField>
+                                                        </subviews>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                    </stackView>
+                                                </subviews>
+                                                <color key="backgroundColor" red="1" green="0.42649608529999999" blue="0.1505924418" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
+                                                        <integer key="value" value="3"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="layer.borderColor">
+                                                        <color key="value" red="0.85828705238726788" green="0.85828705238726788" blue="0.85828705238726788" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" red="1" green="0.42649608529999999" blue="0.1505924418" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" red="0.95887526279898705" green="0.95756792504917609" blue="0.98040385915835548" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstItem="WA5-YQ-jRa" firstAttribute="top" secondItem="8tE-0S-d6L" secondAttribute="top" id="9KZ-DI-mf3"/>
-                                            <constraint firstItem="49R-0v-uMQ" firstAttribute="leading" secondItem="WA5-YQ-jRa" secondAttribute="trailing" constant="3" id="IfM-gD-47X"/>
-                                            <constraint firstAttribute="height" constant="50" id="dtd-51-zuO"/>
-                                            <constraint firstItem="8tE-0S-d6L" firstAttribute="leading" secondItem="d5N-Au-qPb" secondAttribute="leading" constant="8" id="fiJ-y3-bPh"/>
-                                            <constraint firstItem="8tE-0S-d6L" firstAttribute="top" secondItem="d5N-Au-qPb" secondAttribute="top" constant="11.5" id="qCR-Nd-ZdH"/>
-                                            <constraint firstItem="WA5-YQ-jRa" firstAttribute="baseline" secondItem="49R-0v-uMQ" secondAttribute="baseline" id="sOM-uz-ZIv"/>
-                                            <constraint firstAttribute="trailing" secondItem="49R-0v-uMQ" secondAttribute="trailing" constant="8" id="uNZ-PO-gzd"/>
+                                            <constraint firstItem="7XZ-t6-0Xx" firstAttribute="centerY" secondItem="LrA-ea-wSA" secondAttribute="centerY" id="41h-EY-SCt"/>
+                                            <constraint firstItem="7XZ-t6-0Xx" firstAttribute="width" secondItem="LrA-ea-wSA" secondAttribute="width" id="7dh-Qf-vxc"/>
+                                            <constraint firstItem="7XZ-t6-0Xx" firstAttribute="centerX" secondItem="LrA-ea-wSA" secondAttribute="centerX" id="o9z-wY-aZ2"/>
+                                            <constraint firstItem="7XZ-t6-0Xx" firstAttribute="height" secondItem="LrA-ea-wSA" secondAttribute="height" id="wAm-Qp-CN4"/>
                                         </constraints>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                                                 <integer key="value" value="10"/>
                                             </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
+                                                <integer key="value" value="1"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="layer.borderColor">
+                                                <color key="value" red="0.9330756797082228" green="0.9330756797082228" blue="0.9330756797082228" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VQt-4a-LtF" userLabel="BodyFat">
-                                        <rect key="frame" x="0.0" y="124" width="343" height="50"/>
+                                        <rect key="frame" x="0.0" y="209" width="343" height="50"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="bottom" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="%" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3ZO-bM-hPK">
                                                 <rect key="frame" x="317.5" y="28.5" width="17.5" height="14.5"/>
@@ -256,7 +333,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4Br-JZ-yls" userLabel="Muscle">
-                                        <rect key="frame" x="0.0" y="186" width="343" height="50"/>
+                                        <rect key="frame" x="0.0" y="271" width="343" height="50"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="bottom" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="%" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AmT-91-oSa">
                                                 <rect key="frame" x="317.5" y="28.5" width="17.5" height="14.5"/>
@@ -298,7 +375,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BfC-51-zDd">
-                                        <rect key="frame" x="0.0" y="248" width="343" height="36"/>
+                                        <rect key="frame" x="0.0" y="333" width="343" height="36"/>
                                         <color key="backgroundColor" red="0.35943323816194539" green="0.49838710201022451" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                         <state key="normal" title="Save">
@@ -308,11 +385,10 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="s1m-Db-7EI" firstAttribute="trailing" secondItem="UDR-cK-wlW" secondAttribute="trailing" id="6uw-YT-nV8"/>
-                                    <constraint firstItem="WA5-YQ-jRa" firstAttribute="trailing" secondItem="UDR-cK-wlW" secondAttribute="trailing" id="YLb-EN-yZx"/>
+                                    <constraint firstItem="WA5-YQ-jRa" firstAttribute="width" secondItem="UDR-cK-wlW" secondAttribute="width" id="Xkf-iH-mPI"/>
                                     <constraint firstItem="wVK-Z5-HPL" firstAttribute="trailing" secondItem="UDR-cK-wlW" secondAttribute="trailing" id="gGE-9t-BXg"/>
                                     <constraint firstItem="s1m-Db-7EI" firstAttribute="leading" secondItem="UDR-cK-wlW" secondAttribute="leading" id="pvh-8Y-bUl"/>
                                     <constraint firstItem="wVK-Z5-HPL" firstAttribute="leading" secondItem="UDR-cK-wlW" secondAttribute="leading" id="tae-ac-v6u"/>
-                                    <constraint firstItem="WA5-YQ-jRa" firstAttribute="leading" secondItem="UDR-cK-wlW" secondAttribute="leading" id="uon-iC-aEa"/>
                                 </constraints>
                             </stackView>
                         </subviews>
@@ -328,6 +404,10 @@
                     </view>
                     <connections>
                         <outlet property="bodyFatTextField" destination="wVK-Z5-HPL" id="VKh-Zu-igD"/>
+                        <outlet property="calibrationFields" destination="Owk-ao-Zos" id="mdo-dD-4m6"/>
+                        <outlet property="calibrationInfoSwitch" destination="RuH-4O-40I" id="gM7-6g-IvZ"/>
+                        <outlet property="calibrationTextFieldActual" destination="rg2-yE-t4Q" id="kf3-LR-ske"/>
+                        <outlet property="calibrationTextFieldExpected" destination="UoH-C8-ZLc" id="wKg-D8-5eX"/>
                         <outlet property="heightTextField" destination="UDR-cK-wlW" id="Dvt-Wl-MKP"/>
                         <outlet property="muscleTextField" destination="s1m-Db-7EI" id="FfH-fc-8qc"/>
                         <outlet property="saveButton" destination="BfC-51-zDd" id="RDn-8k-3Cf"/>

--- a/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordPresenter.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordPresenter.swift
@@ -9,6 +9,14 @@
 import Foundation
 import RxSwift
 
+typealias NewRecordViewModel = (height: UInt, weight: Double, muscle: Double, bodyFat: Double)
+private func record(applyingCalibration calibration: Double, to record: NewRecordViewModel) -> NewRecordViewModel {
+    return NewRecordViewModel(height: record.height,
+                              weight: record.weight * calibration,
+                              muscle: record.muscle,
+                              bodyFat: record.bodyFat)
+}
+
 typealias INewRecordPresenter =
     (ILatestRecordInteractor,
     INewRecordInteractor,
@@ -28,7 +36,9 @@ let NewRecordPresenter: INewRecordPresenter = { latestRecordInteractor, insertNe
         .addDisposableTo(disposeBag)
     
     view.rx_actionSave
-        .flatMap(mapViewModelToFitnessInfo)
+        .flatMap {
+            Observable.just(record(applyingCalibration: view.calibrationFix, to: $0))
+        }.flatMap(mapViewModelToFitnessInfo)
         .flatMap { insertNewRecordInteractor.rx_save(record: $0) }
         .do(onNext: { _ in loadLatestResult() })
         .subscribe { _ in view.dismiss() }

--- a/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordView.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordView.swift
@@ -17,6 +17,7 @@ protocol INewRecordView: class {
     
     var rx_viewDidLoad: Observable<Void> { get }
     var rx_actionSave: Observable<NewRecordViewModel> { get }
+    var calibrationFix: Double { get }
     
     func dismiss()
 }

--- a/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordViewController.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordViewController.swift
@@ -24,8 +24,6 @@ extension UITextField {
     }
 }
 
-typealias NewRecordViewModel = (height: UInt, weight: Double, muscle: Double, bodyFat: Double)
-
 final class NewRecordViewController: UIViewController {
     @IBOutlet fileprivate var heightTextField: UITextField!
     @IBOutlet fileprivate var weightTextField: UITextField!
@@ -83,7 +81,7 @@ extension NewRecordViewController: INewRecordView {
         return saveSubject.asObservable()
     }
     
-    var calibrationPercentage: Double {
+    var calibrationFix: Double {
         guard calibrationInfoSwitch.isOn else { return 1.0 }
         guard let actualReading = calibrationTextFieldActual.text?.doubleValue,
             let expectedReading = calibrationTextFieldExpected.text?.doubleValue else {
@@ -94,7 +92,7 @@ extension NewRecordViewController: INewRecordView {
     }
     
     var viewModel: NewRecordViewModel {
-        return (height: height, weight: weight * calibrationPercentage, muscle: musclePercentage, bodyFat: bodyFatPercentage)
+        return (height: height, weight: weight, muscle: musclePercentage, bodyFat: bodyFatPercentage)
     }
     
     var height: UInt {

--- a/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordViewController.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordViewController.swift
@@ -65,11 +65,7 @@ final class NewRecordViewController: UIViewController {
             .addDisposableTo(disposeBag)
         
         viewDidLoadSubject.onNext()
-    }
-    
-    func endEditing(_ gestureRecognizer: UIGestureRecognizer) {
-        self.setEditing(false, animated: true)
-    }
+    }    
 }
 
 extension NewRecordViewController: INewRecordView {


### PR DESCRIPTION
Sometimes the scales are not accurate, and the values expected and seen don’t match. In order to get a more accurate reading, a reference weight (an object which weight is known) can be used to see what’s the error seen in the scale. Those values can be specified as part as the `NewRecord` screen.