### PR TITLE
Adds water tracking to the list of the metrics

### DIFF
--- a/Clients/Apple/FitnessTracker/FitnessTracker.xcodeproj/project.pbxproj
+++ b/Clients/Apple/FitnessTracker/FitnessTracker.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		20E89E671E130C5C00F03644 /* ShowMetricHistoricalDataVIP.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShowMetricHistoricalDataVIP.swift; sourceTree = "<group>"; };
 		20E89E691E130D3D00F03644 /* ShowMetricHistoricalDataViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShowMetricHistoricalDataViewController.swift; sourceTree = "<group>"; };
 		20E89E6B1E130D6900F03644 /* MetricReadingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetricReadingTableViewCell.swift; sourceTree = "<group>"; };
+		20F0BC171E16E86E00695F2A /* CoreDataModel_v2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = CoreDataModel_v2.xcdatamodel; sourceTree = "<group>"; };
 		20FA50FA1E095712002E536A /* LatestRecordInteractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = LatestRecordInteractor.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		20FA50FD1E09575E002E536A /* FitnessInfoRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FitnessInfoRepository.swift; sourceTree = "<group>"; };
 		20FA51001E09579F002E536A /* LatestRecordView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = LatestRecordView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -696,9 +697,10 @@
 		202142091E0D248900BAF444 /* CoreDataModel.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				20F0BC171E16E86E00695F2A /* CoreDataModel_v2.xcdatamodel */,
 				2021420A1E0D248900BAF444 /* CoreDataModel.xcdatamodel */,
 			);
-			currentVersion = 2021420A1E0D248900BAF444 /* CoreDataModel.xcdatamodel */;
+			currentVersion = 20F0BC171E16E86E00695F2A /* CoreDataModel_v2.xcdatamodel */;
 			path = CoreDataModel.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Base.lproj/Main.storyboard
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Base.lproj/Main.storyboard
@@ -55,7 +55,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <color key="backgroundColor" red="1" green="0.42649608530966177" blue="0.15059244182690479" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="backgroundColor" red="1" green="0.4259917140007019" blue="0.15029886364936829" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="trailing" secondItem="h5V-Xd-jvE" secondAttribute="trailing" constant="5" id="33r-UL-nOG"/>
                                                 <constraint firstItem="rgo-EF-NeY" firstAttribute="leading" secondItem="l3f-OM-oyD" secondAttribute="leading" constant="8" id="9H9-97-FRL"/>
@@ -124,7 +124,7 @@
                                 </items>
                             </navigationBar>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Bn6-5R-vl7">
-                                <rect key="frame" x="16" y="74" width="343" height="369"/>
+                                <rect key="frame" x="16" y="74" width="343" height="431"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hFF-Hf-jvm" userLabel="Height">
                                         <rect key="frame" x="0.0" y="0.0" width="343" height="50"/>
@@ -374,8 +374,50 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ehc-Jq-xb4" userLabel="Water">
+                                        <rect key="frame" x="0.0" y="333" width="343" height="50"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="bottom" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="%" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gJW-Iw-nSb">
+                                                <rect key="frame" x="317.5" y="28.5" width="17.5" height="14.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="0.79670724690000005" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Water" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bnx-xa-9ut">
+                                                <rect key="frame" x="8" y="12" width="44" height="18"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6tb-Nm-hSe">
+                                                <rect key="frame" x="204.5" y="12" width="110" height="30"/>
+                                                <color key="backgroundColor" red="0.99639644859999998" green="1" blue="0.97138376749999999" alpha="0.14999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="35"/>
+                                                <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
+                                                <connections>
+                                                    <outlet property="delegate" destination="IdY-KO-rib" id="W6G-cY-FBq"/>
+                                                </connections>
+                                            </textField>
+                                        </subviews>
+                                        <color key="backgroundColor" red="1" green="0.42649608529999999" blue="0.1505924418" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstItem="6tb-Nm-hSe" firstAttribute="top" secondItem="bnx-xa-9ut" secondAttribute="top" id="7Uc-PH-ANX"/>
+                                            <constraint firstItem="bnx-xa-9ut" firstAttribute="top" secondItem="Ehc-Jq-xb4" secondAttribute="top" constant="11.5" id="Kwv-GD-8oh"/>
+                                            <constraint firstAttribute="height" constant="50" id="MB7-ee-6xe"/>
+                                            <constraint firstItem="bnx-xa-9ut" firstAttribute="leading" secondItem="Ehc-Jq-xb4" secondAttribute="leading" constant="8" id="Uao-av-eRz"/>
+                                            <constraint firstItem="6tb-Nm-hSe" firstAttribute="baseline" secondItem="gJW-Iw-nSb" secondAttribute="baseline" id="VCV-F3-SkQ"/>
+                                            <constraint firstAttribute="trailing" secondItem="gJW-Iw-nSb" secondAttribute="trailing" constant="8" id="hi3-6t-5py"/>
+                                            <constraint firstItem="gJW-Iw-nSb" firstAttribute="leading" secondItem="6tb-Nm-hSe" secondAttribute="trailing" constant="3" id="u0K-O5-qzd"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="10"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BfC-51-zDd">
-                                        <rect key="frame" x="0.0" y="333" width="343" height="36"/>
+                                        <rect key="frame" x="0.0" y="395" width="343" height="36"/>
                                         <color key="backgroundColor" red="0.35943323816194539" green="0.49838710201022451" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                         <state key="normal" title="Save">
@@ -386,8 +428,10 @@
                                 <constraints>
                                     <constraint firstItem="s1m-Db-7EI" firstAttribute="trailing" secondItem="UDR-cK-wlW" secondAttribute="trailing" id="6uw-YT-nV8"/>
                                     <constraint firstItem="WA5-YQ-jRa" firstAttribute="width" secondItem="UDR-cK-wlW" secondAttribute="width" id="Xkf-iH-mPI"/>
+                                    <constraint firstItem="6tb-Nm-hSe" firstAttribute="width" secondItem="s1m-Db-7EI" secondAttribute="width" id="YfA-Pl-APt"/>
                                     <constraint firstItem="wVK-Z5-HPL" firstAttribute="trailing" secondItem="UDR-cK-wlW" secondAttribute="trailing" id="gGE-9t-BXg"/>
                                     <constraint firstItem="s1m-Db-7EI" firstAttribute="leading" secondItem="UDR-cK-wlW" secondAttribute="leading" id="pvh-8Y-bUl"/>
+                                    <constraint firstItem="gJW-Iw-nSb" firstAttribute="width" secondItem="AmT-91-oSa" secondAttribute="width" id="t6P-Nx-PX7"/>
                                     <constraint firstItem="wVK-Z5-HPL" firstAttribute="leading" secondItem="UDR-cK-wlW" secondAttribute="leading" id="tae-ac-v6u"/>
                                 </constraints>
                             </stackView>
@@ -411,6 +455,7 @@
                         <outlet property="heightTextField" destination="UDR-cK-wlW" id="Dvt-Wl-MKP"/>
                         <outlet property="muscleTextField" destination="s1m-Db-7EI" id="FfH-fc-8qc"/>
                         <outlet property="saveButton" destination="BfC-51-zDd" id="RDn-8k-3Cf"/>
+                        <outlet property="waterTextField" destination="6tb-Nm-hSe" id="q3M-Pn-2Td"/>
                         <outlet property="weightTextField" destination="WA5-YQ-jRa" id="Muj-iX-IsG"/>
                     </connections>
                 </viewController>
@@ -431,7 +476,7 @@
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="L80-8t-fZT" id="oDg-Po-y7Z">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wCM-JK-ivX">

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Data/CoreDataModel.xcdatamodeld/.xccurrentversion
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Data/CoreDataModel.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>CoreDataModel.xcdatamodel</string>
+	<string>CoreDataModel_v2.xcdatamodel</string>
 </dict>
 </plist>

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Data/CoreDataModel.xcdatamodeld/CoreDataModel_v2.xcdatamodel/contents
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Data/CoreDataModel.xcdatamodeld/CoreDataModel_v2.xcdatamodel/contents
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="11759" systemVersion="16C67" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="FitnessInfo" representedClassName=".CoreDataFitnessInfo" syncable="YES" codeGenerationType="class">
+        <attribute name="bodyFatPercentage" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="date" attributeType="Date" minDateTimeInterval="504091500" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="height_" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="musclePercentage" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="waterPercentage" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="weight" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="FitnessInfo" positionX="-63" positionY="-18" width="128" height="135"/>
+    </elements>
+</model>

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Data/CoreDataStack.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Data/CoreDataStack.swift
@@ -60,10 +60,11 @@ internal let CoreDataStackInitializer: ICoreDataStackInitializer = {
             let urls = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
             let docURL = urls[urls.endIndex - 1]
             let storeURL = docURL.appendingPathComponent("FitnessTrackerDataModel.sqlite")
+            let options = [NSMigratePersistentStoresAutomaticallyOption: true, NSInferMappingModelAutomaticallyOption: true]
             
             do {
                 let psc = moc.persistentStoreCoordinator!
-                try psc.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeURL, options: nil)
+                try psc.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeURL, options: options)
             } catch {
                 fatalError("Error migrating store: \(error)")
             }

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Data/FitnessInfo+Operators.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Data/FitnessInfo+Operators.swift
@@ -23,5 +23,6 @@ func -(lhs: IFitnessInfo, rhs: IFitnessInfo) -> IFitnessInfo {
     return FitnessInfo(weight: lhs.weight - rhs.weight,
                        height: lhs.height - lhs.height,
                        bodyFatPercentage: lhs.bodyFatPercentage - rhs.bodyFatPercentage,
-                       musclePercentage: lhs.musclePercentage - rhs.musclePercentage)
+                       musclePercentage: lhs.musclePercentage - rhs.musclePercentage,
+                       waterPercentage: lhs.waterPercentage - rhs.waterPercentage)
 }

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Data/FitnessInfoRepository.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Data/FitnessInfoRepository.swift
@@ -110,6 +110,7 @@ final class CoreDataInfoRepository: IFitnessInfoRepository {
             saved.weight = record.weight
             saved.musclePercentage = record.musclePercentage
             saved.bodyFatPercentage = record.bodyFatPercentage
+            saved.waterPercentage = record.waterPercentage
             saved.date = NSDate()
         }.do(onNext: { [weak self] _ in
             self?.rx_updatedSubject.onNext()

--- a/Clients/Apple/FitnessTracker/FitnessTracker/FitnessInfo.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/FitnessInfo.swift
@@ -16,6 +16,7 @@ public protocol IFitnessInfo {
     var height: UInt { get }
     var bodyFatPercentage: Double { get }
     var musclePercentage: Double { get }
+    var waterPercentage: Double { get }
     var date: NSDate? { get }
 }
 
@@ -24,12 +25,13 @@ public struct FitnessInfo: IFitnessInfo {
     public let height: UInt
     public let bodyFatPercentage: Double
     public let musclePercentage: Double
+    public let waterPercentage: Double
     public let date: NSDate? = nil
 }
 
 public extension FitnessInfo {
     static var empty: IFitnessInfo = {
-        return FitnessInfo(weight: 0, height: 0, bodyFatPercentage: 0, musclePercentage: 0)
+        return FitnessInfo(weight: 0, height: 0, bodyFatPercentage: 0, musclePercentage: 0, waterPercentage: 0)
     }()
 }
 
@@ -44,6 +46,10 @@ public extension IFitnessInfo {
     
     var muscleWeight: Double {
         return Double(weight) * (musclePercentage/100)
+    }
+    
+    var waterWeight: Double {
+        return Double(weight) * (waterPercentage/100)
     }
     
     var bmi: Double {

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Info.plist
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Clients/Apple/FitnessTracker/FitnessTracker/VIP/ShowMetricHistoricalDataVIP.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/VIP/ShowMetricHistoricalDataVIP.swift
@@ -14,8 +14,10 @@ enum BodyMetric: String {
     case weight
     case bodyFatPercentage
     case musclePercentage
+    case waterPercentage
     case bodyFatWeight
     case muscleWeight
+    case waterWeight
     case leanBodyWeight
     case bmi
 }
@@ -27,8 +29,10 @@ extension BodyMetric {
         case .weight: return "Weight"
         case .bodyFatPercentage: return "Body Fat (%)"
         case .musclePercentage: return "Muscle (%)"
+        case .waterPercentage: return "Water (%)"
         case .bodyFatWeight: return "Body Fat (Kg)"
         case .muscleWeight: return "Muscle (Kg)"
+        case .waterWeight: return "Water (Kg)"
         case .leanBodyWeight: return "Lean Body Weight (Kg)"
         case .bmi: return "BMI"
         }
@@ -96,6 +100,10 @@ private extension IFitnessInfo {
             return NSNumber(value: self.musclePercentage)
         case .muscleWeight:
             return NSNumber(value: self.muscleWeight)
+        case .waterPercentage:
+            return NSNumber(value: self.waterPercentage)
+        case .waterWeight:
+            return NSNumber(value: self.waterWeight)
         case .leanBodyWeight:
             return NSNumber(value: self.leanBodyWeight)
         }

--- a/Clients/Apple/FitnessTracker/FitnessTracker/View/LatestRecordView.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/View/LatestRecordView.swift
@@ -14,8 +14,10 @@ struct LatestRecordViewModel {
     let height: UInt
     let bodyFat: Double
     let muscle: Double
+    let water: Double
     let bodyFatWeight: Double
     let muscleWeight: Double
+    let waterWeight: Double
     let leanBodyWeight: Double
     let bmi: Double
 }
@@ -26,8 +28,10 @@ extension LatestRecordViewModel {
                                    height: 0,
                                    bodyFat: 0,
                                    muscle: 0,
+                                   water: 0,
                                    bodyFatWeight: 0,
                                    muscleWeight: 0,
+                                   waterWeight: 0,
                                    leanBodyWeight: 0,
                                    bmi: 0)
     }()
@@ -37,8 +41,10 @@ extension LatestRecordViewModel {
                                    height: fitnessInfo.height,
                                    bodyFat: fitnessInfo.bodyFatPercentage,
                                    muscle: fitnessInfo.musclePercentage,
+                                   water: fitnessInfo.waterPercentage,
                                    bodyFatWeight: fitnessInfo.bodyFatWeight,
                                    muscleWeight: fitnessInfo.muscleWeight,
+                                   waterWeight: fitnessInfo.waterWeight,
                                    leanBodyWeight: fitnessInfo.leanBodyWeight,
                                    bmi: fitnessInfo.bmi)
     }

--- a/Clients/Apple/FitnessTracker/FitnessTracker/View/LatestRecordViewController.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/View/LatestRecordViewController.swift
@@ -70,7 +70,7 @@ extension LatestRecordViewController {
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 8
+        return 10
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -88,6 +88,8 @@ extension LatestRecordViewController {
         
         if indexPath.section == 1 {
             cell.container.backgroundColor = UIColor(red: 0.529, green: 0.176, blue: 0.384, alpha: 1.0)
+        } else {
+            cell.container.backgroundColor = UIColor(red: 0.99, green: 0.43, blue: 0.20, alpha: 1.0)
         }
         
         return cell
@@ -103,10 +105,14 @@ extension LatestRecordViewController {
             return ("Body Fat", String(format: "%.2f", latestRecordView.viewModel.bodyFat), "%", String(format: "%.2f %%", previousLatestResult.value.bodyFat))
         case .musclePercentage:
             return ("Muscle", String(format: "%.2f", latestRecordView.viewModel.muscle), "%", String(format: "%.2f %%", previousLatestResult.value.muscle))
+        case .waterPercentage:
+            return ("Water", String(format: "%.2f", latestRecordView.viewModel.water), "%", String(format: "%.2f %%", previousLatestResult.value.water))
         case .bodyFatWeight:
             return ("Body Fat Weight", String(format: "%.2f", latestRecordView.viewModel.bodyFatWeight), "kg", String(format: "%.2f kg",previousLatestResult.value.bodyFatWeight))
         case .muscleWeight:
             return ("Muscle Weight", String(format: "%.2f", latestRecordView.viewModel.muscleWeight), "kg", String(format: "%.2f kg",previousLatestResult.value.muscleWeight))
+        case .waterWeight:
+            return ("Water Weight", String(format: "%.2f", latestRecordView.viewModel.waterWeight), "kg", String(format: "%.2f kg", previousLatestResult.value.waterWeight))
         case .leanBodyWeight:
             return ("Lean Body Weight", String(format: "%.2f", latestRecordView.viewModel.leanBodyWeight), "kg", String(format: "%.2f kg",previousLatestResult.value.leanBodyWeight))
         case .bmi:
@@ -120,10 +126,12 @@ extension LatestRecordViewController {
         case (0, 1): return .weight
         case (0, 2): return .bodyFatPercentage
         case (0, 3): return .musclePercentage
+        case (0, 4): return .waterPercentage
         case (1, 0): return .bodyFatWeight
         case (1, 1): return .muscleWeight
-        case (1, 2): return .leanBodyWeight
-        case (1, 3): return .bmi
+        case (1, 2): return .waterWeight
+        case (1, 3): return .leanBodyWeight
+        case (1, 4): return .bmi
         
         default: fatalError()
         }

--- a/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordPresenter.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordPresenter.swift
@@ -9,12 +9,13 @@
 import Foundation
 import RxSwift
 
-typealias NewRecordViewModel = (height: UInt, weight: Double, muscle: Double, bodyFat: Double)
+typealias NewRecordViewModel = (height: UInt, weight: Double, muscle: Double, bodyFat: Double, water: Double)
 private func record(applyingCalibration calibration: Double, to record: NewRecordViewModel) -> NewRecordViewModel {
     return NewRecordViewModel(height: record.height,
                               weight: record.weight * calibration,
                               muscle: record.muscle,
-                              bodyFat: record.bodyFat)
+                              bodyFat: record.bodyFat,
+                              water: record.water)
 }
 
 typealias INewRecordPresenter =
@@ -53,6 +54,7 @@ func mapFitnessInfoToView(view: INewRecordView) -> (IFitnessInfo) -> Void {
         view.weight = info.weight
         view.bodyFatPercentage = info.bodyFatPercentage
         view.musclePercentage = info.musclePercentage
+        view.waterPercentage = info.waterPercentage
     }
 }
 
@@ -60,7 +62,8 @@ func mapViewModelToFitnessInfo(viewModel: NewRecordViewModel) -> Observable<IFit
     let fitnessInfo = FitnessInfo(weight: viewModel.weight,
                                   height: viewModel.height,
                                   bodyFatPercentage: viewModel.bodyFat,
-                                  musclePercentage: viewModel.muscle)
+                                  musclePercentage: viewModel.muscle,
+                                  waterPercentage: viewModel.water)
     
     return Observable.just(fitnessInfo)
 }

--- a/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordView.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordView.swift
@@ -14,6 +14,7 @@ protocol INewRecordView: class {
     var weight: Double { get set }
     var bodyFatPercentage: Double { get set }
     var musclePercentage: Double { get set }
+    var waterPercentage: Double { get set }
     
     var rx_viewDidLoad: Observable<Void> { get }
     var rx_actionSave: Observable<NewRecordViewModel> { get }

--- a/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordViewController.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordViewController.swift
@@ -29,6 +29,7 @@ final class NewRecordViewController: UIViewController {
     @IBOutlet fileprivate var weightTextField: UITextField!
     @IBOutlet fileprivate var muscleTextField: UITextField!
     @IBOutlet fileprivate var bodyFatTextField: UITextField!
+    @IBOutlet fileprivate var waterTextField: UITextField!
     @IBOutlet fileprivate var saveButton: UIButton!
     @IBOutlet fileprivate var calibrationInfoSwitch: UISwitch!
     @IBOutlet fileprivate var calibrationFields: UIStackView!
@@ -88,7 +89,7 @@ extension NewRecordViewController: INewRecordView {
     }
     
     var viewModel: NewRecordViewModel {
-        return (height: height, weight: weight, muscle: musclePercentage, bodyFat: bodyFatPercentage)
+        return (height: height, weight: weight, muscle: musclePercentage, bodyFat: bodyFatPercentage, water: waterPercentage)
     }
     
     var height: UInt {
@@ -108,7 +109,12 @@ extension NewRecordViewController: INewRecordView {
 
     var musclePercentage: Double {
         get { return muscleTextField.text != nil ? muscleTextField.textAsDouble! : 0 }
-        set { muscleTextField.text = String(format: "%1.f", newValue) }
+        set { muscleTextField.text = String(format: "%.1f", newValue) }
+    }
+    
+    var waterPercentage: Double {
+        get { return waterTextField.text != nil ? waterTextField.textAsDouble! : 0 }
+        set { waterTextField.text = String(format: "%.1f", newValue) }
     }
     
     func dismiss() {


### PR DESCRIPTION
Water is an interesting metric that might provide a more accurate picture along with _muscle_ and _fat_. In order to add water tracking, the core data model needs to be updated (add a new field) and the old model migrated to the new one. Luckily, this can be done with the lightweight migration mechanism since Core Data can infer the migration model.