### PR TITLE
Fixes an issue when displaying the current week on the first day of the week

### DIFF
--- a/Clients/Apple/FitnessTracker/FitnessTracker.xcodeproj/project.pbxproj
+++ b/Clients/Apple/FitnessTracker/FitnessTracker.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		39F988971E46556E008A1DB6 /* IFitnessInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F988951E465523008A1DB6 /* IFitnessInfoRepository.swift */; };
 		39F988991E46559D008A1DB6 /* CoreDataQueryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F988981E46559D008A1DB6 /* CoreDataQueryRequest.swift */; };
 		39F9889A1E4656CA008A1DB6 /* CoreDataQueryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F988981E46559D008A1DB6 /* CoreDataQueryRequest.swift */; };
+		39F9889C1E48878E008A1DB6 /* MetricGraphInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F9889B1E48878E008A1DB6 /* MetricGraphInteractorTests.swift */; };
 		3C7E764AE3C8B71A2F15C64D /* Pods_TodayExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7EBF53B2E60378C64BDDE11 /* Pods_TodayExtension.framework */; };
 		45AA81FD1D29B16082BA4BBA /* Pods_FitnessTracker_FitnessTrackerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95868793967C2540BD298442 /* Pods_FitnessTracker_FitnessTrackerTests.framework */; };
 		60DCC2D4BE7EC6D04AACF7B5 /* Pods_FitnessTracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 243E297E8C331F616EE9C451 /* Pods_FitnessTracker.framework */; };
@@ -158,6 +159,7 @@
 		39EE916F1E36405E00F104C8 /* BodyMetric.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyMetric.swift; sourceTree = "<group>"; };
 		39F988951E465523008A1DB6 /* IFitnessInfoRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IFitnessInfoRepository.swift; sourceTree = "<group>"; };
 		39F988981E46559D008A1DB6 /* CoreDataQueryRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataQueryRequest.swift; sourceTree = "<group>"; };
+		39F9889B1E48878E008A1DB6 /* MetricGraphInteractorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetricGraphInteractorTests.swift; sourceTree = "<group>"; };
 		94B5A7A9738E9EE617B4C9E1 /* Pods-TodayExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TodayExtension.release.xcconfig"; path = "Pods/Target Support Files/Pods-TodayExtension/Pods-TodayExtension.release.xcconfig"; sourceTree = "<group>"; };
 		95868793967C2540BD298442 /* Pods_FitnessTracker_FitnessTrackerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FitnessTracker_FitnessTrackerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF97CF9401854D9B0C19B13A /* Pods-FitnessTracker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FitnessTracker.release.xcconfig"; path = "Pods/Target Support Files/Pods-FitnessTracker/Pods-FitnessTracker.release.xcconfig"; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 				204C62151E1046C300B6CE47 /* CoreDataFitnessInfoRepositoryTests.swift */,
 				20E89E641E12F44E00F03644 /* MetricHistoryTests.swift */,
 				20471A471E197E9D0000F7C2 /* InsightsTests.swift */,
+				39F9889B1E48878E008A1DB6 /* MetricGraphInteractorTests.swift */,
 			);
 			path = FitnessTrackerTests;
 			sourceTree = "<group>";
@@ -693,6 +696,7 @@
 				205212FB1E01D3AD00F9A9E7 /* LatestRecordTests.swift in Sources */,
 				20E89E651E12F44E00F03644 /* MetricHistoryTests.swift in Sources */,
 				20471A481E197E9D0000F7C2 /* InsightsTests.swift in Sources */,
+				39F9889C1E48878E008A1DB6 /* MetricGraphInteractorTests.swift in Sources */,
 				200323ED1E0018A500B1C33A /* FitnessTrackerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Data/CoreDataStack.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Data/CoreDataStack.swift
@@ -133,20 +133,14 @@ struct CoreDataEngine {
         }
     }
     
-    func create(entityName: String, configuration: ((NSManagedObject) -> Void)?) -> Observable<NSManagedObject> {
+    func create(entityName: String, configuration: ((NSManagedObject) -> Void)?) throws -> NSManagedObject {
         let newObject = NSEntityDescription.insertNewObject(forEntityName: entityName, into: managedObjectContext)
         
         configuration?(newObject)
         
-        do {
-            try managedObjectContext.save()
-            
-            return Observable.just(newObject)
-        } catch {
-            return Observable
-                .error(NSError(domain: "Core Data", code: -1, userInfo: nil))
-                .do(onNext: nil, onError: { error in NSLog("Failure when saving the context: \(error)") })
-        }
+        try managedObjectContext.save()
+
+        return newObject
     }
 }
 

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Data/FitnessInfoRepository.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Data/FitnessInfoRepository.swift
@@ -55,8 +55,8 @@ final class CoreDataInfoRepository: IFitnessInfoRepository {
             .flatMap { return Observable.just($0 as! [CoreDataFitnessInfo]) }
     }
     
-    @discardableResult func rx_save(record: IFitnessInfo) -> Observable<IFitnessInfo> {
-        return coreDataEngine.create(entityName: CoreDataEntity.fitnessInfo.rawValue) { entity in
+    @discardableResult func save(record: IFitnessInfo) throws -> IFitnessInfo {
+        let result = try coreDataEngine.create(entityName: CoreDataEntity.fitnessInfo.rawValue, configuration: { entity in
             guard let saved = entity as? CoreDataFitnessInfo else { fatalError() }
             
             saved.height_ = Int16(record.height)
@@ -64,12 +64,13 @@ final class CoreDataInfoRepository: IFitnessInfoRepository {
             saved.musclePercentage = record.musclePercentage
             saved.bodyFatPercentage = record.bodyFatPercentage
             saved.waterPercentage = record.waterPercentage
-            saved.date = NSDate()
-        }.do(onNext: { [weak self] _ in
-            self?.rx_updatedSubject.onNext()
-        }).flatMap {
-            return Observable.just($0 as! IFitnessInfo)
-        }
+            saved.date = record.date ?? NSDate()
+        }) as! IFitnessInfo
+        
+        rx_updatedSubject.onNext()
+        
+        return result
     }
+    
 }
 

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Data/FitnessInfoRepository.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Data/FitnessInfoRepository.swift
@@ -55,7 +55,7 @@ final class CoreDataInfoRepository: IFitnessInfoRepository {
             .flatMap { return Observable.just($0 as! [CoreDataFitnessInfo]) }
     }
     
-    @discardableResult func save(record: IFitnessInfo) throws -> IFitnessInfo {
+    @discardableResult func save(_ record: IFitnessInfo) throws -> IFitnessInfo {
         let result = try coreDataEngine.create(entityName: CoreDataEntity.fitnessInfo.rawValue, configuration: { entity in
             guard let saved = entity as? CoreDataFitnessInfo else { fatalError() }
             

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Data/IFitnessInfoRepository.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Data/IFitnessInfoRepository.swift
@@ -20,15 +20,15 @@ protocol IFitnessInfoRepository {
     
     func rx_findAll() -> Observable<[IFitnessInfo]>
     
-    @discardableResult func save(record: IFitnessInfo) throws -> IFitnessInfo
-    @discardableResult func rx_save(record: IFitnessInfo) -> Observable<IFitnessInfo>
+    @discardableResult func save(_ record: IFitnessInfo) throws -> IFitnessInfo
+    @discardableResult func rx_save(_ record: IFitnessInfo) -> Observable<IFitnessInfo>
 }
 
 extension IFitnessInfoRepository {
-    func rx_save(record: IFitnessInfo) -> Observable<IFitnessInfo> {
+    func rx_save(_ record: IFitnessInfo) -> Observable<IFitnessInfo> {
         return Observable.create { observer -> Disposable in
             do {
-                let saved = try self.save(record: record)
+                let saved = try self.save(record)
                 
                 observer.onNext(saved)
                 observer.onCompleted()
@@ -82,7 +82,7 @@ extension IFitnessInfoRepository {
         let disposeBag = DisposeBag()
         
         for record in records {
-            self.rx_save(record: record)
+            self.rx_save(record)
                 .subscribe(onNext: { result.append($0) }, onError: { error = $0 } )
                 .addDisposableTo(disposeBag)
         }

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Data/IFitnessInfoRepository.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Data/IFitnessInfoRepository.swift
@@ -20,10 +20,26 @@ protocol IFitnessInfoRepository {
     
     func rx_findAll() -> Observable<[IFitnessInfo]>
     
+    @discardableResult func save(record: IFitnessInfo) throws -> IFitnessInfo
     @discardableResult func rx_save(record: IFitnessInfo) -> Observable<IFitnessInfo>
 }
 
 extension IFitnessInfoRepository {
+    func rx_save(record: IFitnessInfo) -> Observable<IFitnessInfo> {
+        return Observable.create { observer -> Disposable in
+            do {
+                let saved = try self.save(record: record)
+                
+                observer.onNext(saved)
+                observer.onCompleted()
+            } catch {
+                observer.onError(error)
+            }
+            
+            return Disposables.create { }
+        }
+    }
+    
     func rx_find(from: NSDate, to: NSDate, order: CoreDataQueryRequestOrder) -> Observable<[IFitnessInfo]> {
         return rx_find(from: from, to: to, limit: .noLimit, order: order)
     }

--- a/Clients/Apple/FitnessTracker/FitnessTracker/Extensions/NSCalendar+NSDateFactory.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/Extensions/NSCalendar+NSDateFactory.swift
@@ -64,5 +64,9 @@ extension Calendar {
     func date(addingDays days: Int, to date: Date) -> Date {
         return self.date(byAdding: .day, value: days, to: date)!
     }
+    
+    func dateBySettingStartOfDay(to date: Date) -> Date {
+        return self.date(bySettingHour: 0, minute: 0, second: 0, of: date)!
+    }
 }
 

--- a/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordInteractor.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTracker/View/NewRecordInteractor.swift
@@ -21,6 +21,6 @@ final class NewRecordInteractor: INewRecordInteractor {
     }
     
     func rx_save(record: IFitnessInfo) -> Observable<IFitnessInfo> {
-        return repository.rx_save(record: record)
+        return repository.rx_save(record)
     }
 }

--- a/Clients/Apple/FitnessTracker/FitnessTrackerTests/CommonUtils.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTrackerTests/CommonUtils.swift
@@ -50,3 +50,15 @@ let SetUpInMemoryManagedObjectContext: () -> NSManagedObjectContext = {
     
     return managedObjectContext
 }
+
+extension Calendar {
+    func date(withDay day: Int, month: Int, year: Int, hour: Int, minute: Int) -> Date? {
+        return DateComponents(calendar: Calendar.current,
+                                        timeZone: TimeZone(identifier: "Europe/London"),
+                                        year: year,
+                                        month: month,
+                                        day: day,
+                                        hour: hour,
+                                        minute: minute).date
+    }
+}

--- a/Clients/Apple/FitnessTracker/FitnessTrackerTests/CoreDataFitnessInfoRepositoryTests.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTrackerTests/CoreDataFitnessInfoRepositoryTests.swift
@@ -42,7 +42,7 @@ class CoreDataFitnessInfoRepositoryTests: QuickSpec {
                 
                 it("Can return a single result") {
                     let expected = FitnessInfo(weight: 60.0, height: 171, bodyFatPercentage: 30.0, musclePercentage: 30.0, waterPercentage: 0.0)
-                    repository.rx_save(record: expected)
+                    repository.rx_save(expected)
                         .do(onNext: nil, onError: { _ in fail() })
                         .subscribe(onNext: nil)
                         .addDisposableTo(disposeBag)
@@ -58,6 +58,26 @@ class CoreDataFitnessInfoRepositoryTests: QuickSpec {
                         
                         expect(first == expected).to(beTrue())
                     }, action:{ })
+                }
+                
+                it("Can save a record with set date") {
+                    guard let date = DateComponents(calendar: Calendar.current,
+                                                    timeZone: TimeZone(identifier: "Europe/London"),
+                                                    year: 2017, month: 2, day: 6, hour: 9, minute: 6).date else
+                    {
+                        fail()
+                        return
+                    }
+                    
+                    let info = FitnessInfo(weight: 60.0, height: 171, bodyFatPercentage: 19.2, musclePercentage: 34.10, waterPercentage: 55, date: date as NSDate?)
+                    
+                    do {
+                        let saved = try repository.save(info)
+                        expect(saved.date! as Date).to(equal(date))
+                    } catch {
+                        fail(error.localizedDescription)
+                        return
+                    }
                 }
                 
                 it("Can return several results ordered from latest to oldest") {
@@ -86,7 +106,7 @@ class CoreDataFitnessInfoRepositoryTests: QuickSpec {
                             done()
                         }).addDisposableTo(disposeBag)
                         
-                        repository.rx_save(record: any).subscribe(onNext: nil).addDisposableTo(disposeBag)
+                        repository.rx_save(any).subscribe(onNext: nil).addDisposableTo(disposeBag)
                     }
                 }
             }

--- a/Clients/Apple/FitnessTracker/FitnessTrackerTests/InsightsTests.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTrackerTests/InsightsTests.swift
@@ -66,15 +66,20 @@ class InsightsTests: QuickSpec {
                     
                     for (info, date) in zip(weekFitnessInfo, dates)
                     {
-                        _ = coreDataEngine.create(entityName: CoreDataEntity.fitnessInfo.rawValue) { entity in
-                            guard let saved = entity as? CoreDataFitnessInfo else { fatalError() }
-                            
-                            saved.date = date as NSDate
-                            saved.weight = info.weight
-                            saved.height_ = Int16(info.height)
-                            saved.bodyFatPercentage = info.bodyFatPercentage
-                            saved.musclePercentage = info.musclePercentage
-                            saved.waterPercentage = info.waterPercentage
+                        do {
+                            _ = try coreDataEngine.create(entityName: CoreDataEntity.fitnessInfo.rawValue) { entity in
+                                guard let saved = entity as? CoreDataFitnessInfo else { fatalError() }
+                                
+                                saved.date = date as NSDate
+                                saved.weight = info.weight
+                                saved.height_ = Int16(info.height)
+                                saved.bodyFatPercentage = info.bodyFatPercentage
+                                saved.musclePercentage = info.musclePercentage
+                                saved.waterPercentage = info.waterPercentage
+                            }
+                        } catch {
+                            fail()
+                            return
                         }
                     }
                     

--- a/Clients/Apple/FitnessTracker/FitnessTrackerTests/LatestRecordTests.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTrackerTests/LatestRecordTests.swift
@@ -51,7 +51,12 @@ class LatestRecordTests: QuickSpec {
                 }
                 
                 it("Shows the latest record data") {
-                    repository.rx_save(record: FitnessInfo(weight: 34.5, height: 171, bodyFatPercentage: 30.0, musclePercentage: 30.0, waterPercentage: 41.0))
+                    do {
+                        try repository.save(record: FitnessInfo(weight: 34.5, height: 171, bodyFatPercentage: 30.0, musclePercentage: 30.0, waterPercentage: 41.0))
+                    } catch {
+                        fail()
+                        return
+                    }
                     
                     createObserverAndSubscribe(to: view.viewModelVariable.asObservable().skip(1), scheduler: scheduler, disposeBag: disposeBag, expect: { viewModel in
                         expect(viewModel.weight - 34.5 < 0.000001).to(beTrue())

--- a/Clients/Apple/FitnessTracker/FitnessTrackerTests/LatestRecordTests.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTrackerTests/LatestRecordTests.swift
@@ -52,7 +52,7 @@ class LatestRecordTests: QuickSpec {
                 
                 it("Shows the latest record data") {
                     do {
-                        try repository.save(record: FitnessInfo(weight: 34.5, height: 171, bodyFatPercentage: 30.0, musclePercentage: 30.0, waterPercentage: 41.0))
+                        try repository.save(FitnessInfo(weight: 34.5, height: 171, bodyFatPercentage: 30.0, musclePercentage: 30.0, waterPercentage: 41.0))
                     } catch {
                         fail()
                         return

--- a/Clients/Apple/FitnessTracker/FitnessTrackerTests/MetricGraphInteractorTests.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTrackerTests/MetricGraphInteractorTests.swift
@@ -1,0 +1,24 @@
+//
+//  MetricGraphInteractorTests.swift
+//  FitnessTracker
+//
+//  Created by Alberto Chamorro on 06/02/2017.
+//  Copyright © 2017 OnsetBits. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import FitnessTracker
+
+class MetricGraphInteractorTests: QuickSpec {
+    override func spec() {
+        describe("") {
+            it("Retrieves the results of the current week") {
+//                let managedObject = SetUpInMemoryManagedObjectContext()
+//                let fitnessInfo = FitnessInfo(weight: 67.01, height: 171, bodyFatPercentage: 19.10, musclePercentage: 34.10, waterPercentage: 55)
+//                let repository = CoreDataInfoRepository(managedObjectContext: managedObject)
+//                repository.rx_save(record: <#T##IFitnessInfo#>)
+            }
+        }
+    }
+}

--- a/Clients/Apple/FitnessTracker/FitnessTrackerTests/MetricGraphInteractorTests.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTrackerTests/MetricGraphInteractorTests.swift
@@ -8,16 +8,47 @@
 
 import Quick
 import Nimble
+import RxSwift
 @testable import FitnessTracker
 
 class MetricGraphInteractorTests: QuickSpec {
     override func spec() {
         describe("") {
             it("Retrieves the results of the current week") {
-//                let managedObject = SetUpInMemoryManagedObjectContext()
-//                let fitnessInfo = FitnessInfo(weight: 67.01, height: 171, bodyFatPercentage: 19.10, musclePercentage: 34.10, waterPercentage: 55)
-//                let repository = CoreDataInfoRepository(managedObjectContext: managedObject)
-//                repository.rx_save(record: <#T##IFitnessInfo#>)
+                let managedObject = SetUpInMemoryManagedObjectContext()
+                let repository = CoreDataInfoRepository(managedObjectContext: managedObject)
+
+                var components = DateComponents(calendar: Calendar.current, timeZone: TimeZone(identifier: "Europe/London"),
+                                                year: 2017, month: 2, day: 6, hour: 9, minute: 6)
+                
+                do {
+                    let date = components.date!
+                    let fitnessInfo = FitnessInfo(weight: 67.01, height: 171, bodyFatPercentage: 19.10, musclePercentage: 34.10, waterPercentage: 55, date: date as NSDate)
+
+                    try repository.save(fitnessInfo)
+                } catch {
+                    fail()
+                
+                    return
+                }
+                
+                components.minute = 0
+                components.hour = 0
+                
+                let disposeBag = DisposeBag()
+                let date = components.date!
+                let interactor = MetricGraphInteractor(repository: repository)
+
+                waitUntil { done in
+                    interactor.find(from: Calendar.current.dateBySettingStartOfDay(to: date))
+                        .subscribe(onNext: { records in
+                            expect(records.count).to(equal(1))
+                            done()
+                        }, onError: { _ in
+                            fail()
+                            done()
+                        }).addDisposableTo(disposeBag)
+                }
             }
         }
     }

--- a/Clients/Apple/FitnessTracker/FitnessTrackerTests/NewRecordTests.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTrackerTests/NewRecordTests.swift
@@ -77,7 +77,7 @@ class NewRecordTests: QuickSpec {
                 
                 it("Shows the previous reading when there is some previous data") {
                     do {
-                        try repository.save(record: FitnessInfo(weight: 65.0, height: 171, bodyFatPercentage: 30.0, musclePercentage: 40.0, waterPercentage: 40.0))
+                        try repository.save(FitnessInfo(weight: 65.0, height: 171, bodyFatPercentage: 30.0, musclePercentage: 40.0, waterPercentage: 40.0))
                     } catch {
                         fail()
                         return

--- a/Clients/Apple/FitnessTracker/FitnessTrackerTests/NewRecordTests.swift
+++ b/Clients/Apple/FitnessTracker/FitnessTrackerTests/NewRecordTests.swift
@@ -76,7 +76,12 @@ class NewRecordTests: QuickSpec {
                 }
                 
                 it("Shows the previous reading when there is some previous data") {
-                    repository.rx_save(record: FitnessInfo(weight: 65.0, height: 171, bodyFatPercentage: 30.0, musclePercentage: 40.0, waterPercentage: 40.0))
+                    do {
+                        try repository.save(record: FitnessInfo(weight: 65.0, height: 171, bodyFatPercentage: 30.0, musclePercentage: 40.0, waterPercentage: 40.0))
+                    } catch {
+                        fail()
+                        return
+                    }
                     
                     view.viewDidLoad()
                     


### PR DESCRIPTION
The bug was caused when searching all the records within an interval. The time of the supplied hours was not reset to zero and, hence, the records of the same day but with a time previous of the today weren't shown. It has been fixed by adding to the presenter the logic to set the `Date` time to the beginning of the day.

Besides, `save` in the repository and `create` in the `CoreDataEngine` are now a synchronous calls that can throw.